### PR TITLE
[feat] document hash on file upload and info linking to notary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4615,6 +4615,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+    },
     "css": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "camelcase": "^5.2.0",
     "case-sensitive-paths-webpack-plugin": "2.2.0",
     "core-util-is": "^1.0.2",
+    "crypto-js": "^3.1.9-1",
     "css-loader": "2.1.1",
     "dotenv": "6.2.0",
     "dotenv-expand": "5.1.0",

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -264,3 +264,13 @@ input.ant-input {
 .ant-modal-body .ant-card {
   max-width: 100%;
 }
+
+.ant-upload.ant-upload-drag {
+  border: 1px solid #eaedf3;
+  border-radius: 8px;
+  background: #d3d3d3;
+}
+
+.ant-upload-list-item:hover .ant-upload-list-item-info {
+  background-color: #ffffff;
+}

--- a/src/utils/decodeRawSlpTransactions.js
+++ b/src/utils/decodeRawSlpTransactions.js
@@ -50,7 +50,7 @@ const decodeTokenDetails = withSLP((SLP, txDetail) => {
         name: Buffer.from(script[5], "hex").toString("ascii"),
         decimals,
         documentUri: Buffer.from(script[6], "hex").toString("ascii"),
-        documentHash: Buffer.from(script[7], "hex").toString("ascii")
+        documentHash: script[7]
       };
       tokenDetails.symbol = Buffer.from(script[4], "hex").toString("ascii");
       tokenDetails.outputs = [

--- a/src/utils/decodeRawSlpTransactions.js
+++ b/src/utils/decodeRawSlpTransactions.js
@@ -50,7 +50,7 @@ const decodeTokenDetails = withSLP((SLP, txDetail) => {
         name: Buffer.from(script[5], "hex").toString("ascii"),
         decimals,
         documentUri: Buffer.from(script[6], "hex").toString("ascii"),
-        documentHash: script[7]
+        documentHash: script[7].startsWith("OP_0") ? "" : script[7]
       };
       tokenDetails.symbol = Buffer.from(script[4], "hex").toString("ascii");
       tokenDetails.outputs = [

--- a/src/utils/getSlpBanlancesAndUtxos.js
+++ b/src/utils/getSlpBanlancesAndUtxos.js
@@ -106,7 +106,7 @@ const decodeTokenMetadata = withSLP((SLP, txDetails) => {
         ? parseInt(script[8].slice(3), 10)
         : parseInt(script[8], 16),
       documentUri: Buffer.from(script[6], "hex").toString("ascii"),
-      documentHash: Buffer.from(script[7], "hex").toString("ascii")
+      documentHash: script[7]
     };
   } else {
     throw new Error("Invalid tx type");

--- a/src/utils/getSlpBanlancesAndUtxos.js
+++ b/src/utils/getSlpBanlancesAndUtxos.js
@@ -106,7 +106,7 @@ const decodeTokenMetadata = withSLP((SLP, txDetails) => {
         ? parseInt(script[8].slice(3), 10)
         : parseInt(script[8], 16),
       documentUri: Buffer.from(script[6], "hex").toString("ascii"),
-      documentHash: script[7]
+      documentHash: script[7].startsWith("OP_0") ? "" : script[7]
     };
   } else {
     throw new Error("Invalid tx type");


### PR DESCRIPTION
- Allow drag and drop for document hash

- Clarify document hash


Before loading the file:
![hash_before_upload](https://user-images.githubusercontent.com/4977560/74104724-48356f00-4b36-11ea-990e-ea1b59a6d0b1.png)


After:
![hash_after_upload](https://user-images.githubusercontent.com/4977560/74104728-4bc8f600-4b36-11ea-9d5f-8ef583765b1f.png)
