### PR TITLE
Fix/burn history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3272,9 +3272,9 @@
       }
     },
     "base-x": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
-      "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -3870,17 +3870,17 @@
       },
       "dependencies": {
         "make-dir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
           "requires": {
             "semver": "^6.0.0"
           }
         },
         "write-file-atomic": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
-          "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
           "requires": {
             "imurmurhash": "^0.1.4",
             "is-typedarray": "^1.0.0",
@@ -6526,9 +6526,9 @@
       "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
     },
     "figlet": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.2.4.tgz",
-      "integrity": "sha512-mv8YA9RruB4C5QawPaD29rEVx3N97ZTyNrE4DAfbhuo6tpcMdKnPVo8MlyT3RP5uPcg5M14bEJBq7kjFf4kAWg=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.3.0.tgz",
+      "integrity": "sha512-f7A8aOJAfyehLJ7lQ6rEA8WJw7kOk3lfWRi5piSjkzbK5YkI5sqO8eiLHz1ehO+DM0QYB85i8VfA6XIGUbU1dg=="
     },
     "figures": {
       "version": "2.0.0",
@@ -7711,9 +7711,9 @@
       }
     },
     "hasha": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
-      "integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
+      "integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
       "requires": {
         "is-stream": "^2.0.0",
         "type-fest": "^0.8.0"
@@ -8634,9 +8634,9 @@
           "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg=="
         },
         "make-dir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
           "requires": {
             "semver": "^6.0.0"
           }
@@ -11080,17 +11080,17 @@
           }
         },
         "@babel/core": {
-          "version": "7.8.4",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
-          "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.6.tgz",
+          "integrity": "sha512-Sheg7yEJD51YHAvLEV/7Uvw95AeWqYPL3Vk3zGujJKIhJ+8oLw2ALaf3hbucILhKsgSoADOvtKRJuNVdcJkOrg==",
           "requires": {
             "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.8.4",
+            "@babel/generator": "^7.8.6",
             "@babel/helpers": "^7.8.4",
-            "@babel/parser": "^7.8.4",
-            "@babel/template": "^7.8.3",
-            "@babel/traverse": "^7.8.4",
-            "@babel/types": "^7.8.3",
+            "@babel/parser": "^7.8.6",
+            "@babel/template": "^7.8.6",
+            "@babel/traverse": "^7.8.6",
+            "@babel/types": "^7.8.6",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.1",
@@ -11109,11 +11109,11 @@
           }
         },
         "@babel/generator": {
-          "version": "7.8.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-          "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
+          "integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
           "requires": {
-            "@babel/types": "^7.8.3",
+            "@babel/types": "^7.8.6",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
             "source-map": "^0.5.0"
@@ -11166,40 +11166,40 @@
           }
         },
         "@babel/parser": {
-          "version": "7.8.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-          "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw=="
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+          "integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g=="
         },
         "@babel/template": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+          "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
           "requires": {
             "@babel/code-frame": "^7.8.3",
-            "@babel/parser": "^7.8.3",
-            "@babel/types": "^7.8.3"
+            "@babel/parser": "^7.8.6",
+            "@babel/types": "^7.8.6"
           }
         },
         "@babel/traverse": {
-          "version": "7.8.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-          "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+          "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
           "requires": {
             "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.8.4",
+            "@babel/generator": "^7.8.6",
             "@babel/helper-function-name": "^7.8.3",
             "@babel/helper-split-export-declaration": "^7.8.3",
-            "@babel/parser": "^7.8.4",
-            "@babel/types": "^7.8.3",
+            "@babel/parser": "^7.8.6",
+            "@babel/types": "^7.8.6",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+          "integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -11265,12 +11265,12 @@
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "find-cache-dir": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-          "integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.0.tgz",
+          "integrity": "sha512-PtXtQb7IrD8O+h6Cq1dbpJH5NzD8+9keN1zZ0YlpDzl1PwXEJEBj6u1Xa92t1Hwluoozd9TNKul5Hi2iqpsWwg==",
           "requires": {
             "commondir": "^1.0.1",
-            "make-dir": "^3.0.0",
+            "make-dir": "^3.0.2",
             "pkg-dir": "^4.1.0"
           }
         },
@@ -11370,9 +11370,9 @@
           }
         },
         "make-dir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
           "requires": {
             "semver": "^6.0.0"
           }
@@ -15027,7 +15027,7 @@
       }
     },
     "slp-sdk": {
-      "version": "git://github.com/lucasmgv/slp-sdk.git#68f8104b63bbfbdb3aaaa5ecffa7ddf30b2a51b9",
+      "version": "git://github.com/lucasmgv/slp-sdk.git#d3c70468b14a22438b13a6c389e59b18993f597c",
       "from": "git://github.com/lucasmgv/slp-sdk.git#feat/bulk_slp_transactions",
       "requires": {
         "@types/bigi": "^1.4.2",
@@ -15436,9 +15436,9 @@
       },
       "dependencies": {
         "make-dir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
           "requires": {
             "semver": "^6.0.0"
           }

--- a/src/components/Portfolio/Portfolio.js
+++ b/src/components/Portfolio/Portfolio.js
@@ -62,7 +62,7 @@ const StyledSwitch = styled(Col)`
 
 export default () => {
   const ContextValue = React.useContext(WalletContext);
-  const { wallet, tokens, loading, balances } = ContextValue;
+  const { wallet, tokens, loading, balances, slpBalancesAndUtxos } = ContextValue;
   const [selectedToken, setSelectedToken] = useState(null);
   const [action, setAction] = useState(null);
   const SLP_TOKEN_ICONS_URL = "https://tokens.bch.sx/64";
@@ -74,7 +74,7 @@ export default () => {
   const [showArchivedTokens, setShowArchivedTokens] = useState(false);
 
   const isModalOpen = (action, selectedToken) => action === "sendBCH" || selectedToken !== null;
-
+  console.log("slpBalancesAndUtxos :", slpBalancesAndUtxos);
   React.useEffect(() => {
     document.body.style.overflow = isModalOpen(action, selectedToken) ? "hidden" : "";
     return () => (document.body.style.overflow = "");
@@ -83,7 +83,11 @@ export default () => {
   const getTokenHistory = async tokenInfo => {
     setLoadingTokenHistory(true);
     try {
-      const resp = await getTokenTransactionHistory(wallet.slpAddresses, tokenInfo);
+      const resp = await getTokenTransactionHistory(
+        wallet.slpAddresses,
+        tokenInfo,
+        slpBalancesAndUtxos.slpUtxos.filter(utxo => utxo.slpData.tokenId === tokenInfo.tokenId)
+      );
       setHistory(resp);
     } catch (err) {
       const message = err.message || err.error || JSON.stringify(err);
@@ -382,7 +386,14 @@ export default () => {
                             <div
                               key={`history-${el.txid}`}
                               style={{
-                                background: el.balance > 0 ? "#D4EFFC" : " #ffd59a",
+                                background:
+                                  el.balance > 0
+                                    ? el.detail.transactionType === "BURN"
+                                      ? "#FDF1F0"
+                                      : "#D4EFFC"
+                                    : el.detail.transactionType.includes("BURN")
+                                    ? "#FDF1F0"
+                                    : "#ffd59a",
                                 color: "black",
                                 borderRadius: "12px",
                                 marginBottom: "18px",
@@ -391,35 +402,60 @@ export default () => {
                                 width: "97%"
                               }}
                             >
-                              <a
-                                href={`https://explorer.bitcoin.com/bch/tx/${el.txid}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
-                                <p>
-                                  {el.balance > 0
-                                    ? el.detail.transactionType === "GENESIS"
-                                      ? "Genesis"
-                                      : el.detail.transactionType === "MINT"
-                                      ? "Mint"
-                                      : "Received"
-                                    : "Sent"}
-                                </p>
-                                <p>{el.date.toLocaleString()}</p>
-
-                                <p>{`${el.balance > 0 ? "+" : ""}${el.balance} ${
-                                  el.detail.symbol
-                                }`}</p>
-
-                                <Paragraph
-                                  small
-                                  ellipsis
-                                  style={{ whiteSpace: "nowrap", color: "black", maxWidth: "90%" }}
+                              {el.detail.transactionType !== "BURN_ALL" ? (
+                                <a
+                                  href={`https://explorer.bitcoin.com/bch/tx/${el.txid}`}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
                                 >
-                                  {el.txid}
-                                </Paragraph>
-                                <p>{`Confirmations: ${el.confirmations}`}</p>
-                              </a>
+                                  <p>
+                                    {el.balance > 0
+                                      ? el.detail.transactionType === "GENESIS"
+                                        ? "Genesis"
+                                        : el.detail.transactionType === "MINT"
+                                        ? "Mint"
+                                        : el.detail.transactionType === "BURN"
+                                        ? "Burn"
+                                        : "Received"
+                                      : el.detail.transactionType === "BURN_BATON"
+                                      ? "Burn Baton"
+                                      : "Sent"}
+                                  </p>
+                                  <p>{el.date.toLocaleString()}</p>
+
+                                  {el.detail.transactionType === "BURN" &&
+                                    (el.detail.burnAmount ? (
+                                      <p>{`${el.detail.burnAmount} ${el.detail.symbol} burned`}</p>
+                                    ) : (
+                                      <p>Burn amount could not be found for this transaction</p>
+                                    ))}
+
+                                  {el.detail.transactionType !== "BURN_BATON" && (
+                                    <p>{`${
+                                      el.balance > 0 && el.detail.transactionType !== "BURN"
+                                        ? "+"
+                                        : ""
+                                    }${el.balance} ${el.detail.symbol} ${
+                                      el.detail.transactionType === "BURN" ? "left" : ""
+                                    }`}</p>
+                                  )}
+
+                                  <Paragraph
+                                    small
+                                    ellipsis
+                                    style={{
+                                      whiteSpace: "nowrap",
+                                      color: "black",
+                                      maxWidth: "90%"
+                                    }}
+                                  >
+                                    {el.txid}
+                                  </Paragraph>
+                                  <p>{`Confirmations: ${el.confirmations}`}</p>
+                                </a>
+                              ) : (
+                                <p>Burn All</p>
+                              )}
                             </div>
                           ))}
                           <a

--- a/src/components/Portfolio/Portfolio.js
+++ b/src/components/Portfolio/Portfolio.js
@@ -74,7 +74,7 @@ export default () => {
   const [showArchivedTokens, setShowArchivedTokens] = useState(false);
 
   const isModalOpen = (action, selectedToken) => action === "sendBCH" || selectedToken !== null;
-  console.log("slpBalancesAndUtxos :", slpBalancesAndUtxos);
+
   React.useEffect(() => {
     document.body.style.overflow = isModalOpen(action, selectedToken) ? "hidden" : "";
     return () => (document.body.style.overflow = "");

--- a/src/components/Portfolio/SendBCH/SendBCH.js
+++ b/src/components/Portfolio/SendBCH/SendBCH.js
@@ -115,9 +115,11 @@ const SendBCH = ({ onClose, outerAction }) => {
       );
       await fetch("https://markets.api.bitcoin.com/live/bitcoin")
         .then(response => {
+          console.log("response :", response);
           return response.json();
         })
         .then(myJson => {
+          console.log("myJson.data.BCH :", myJson.data.BCH);
           setBchToDollar(myJson.data.BCH);
         });
       setHistory(resp);
@@ -285,11 +287,11 @@ const SendBCH = ({ onClose, outerAction }) => {
                               el.transactionBalance.balance
                             } BCH`}</p>
                             <p>{`${el.transactionBalance.balance > 0 ? "+$" : "-$"}${
-                              (Math.abs(el.transactionBalance.balance) / bchToDollar)
+                              (Math.abs(el.transactionBalance.balance) * bchToDollar)
                                 .toFixed(2)
                                 .toString() === "0.00"
                                 ? 0.01
-                                : (Math.abs(el.transactionBalance.balance) / bchToDollar).toFixed(2)
+                                : (Math.abs(el.transactionBalance.balance) * bchToDollar).toFixed(2)
                             } USD`}</p>
                             {el.transactionBalance.type.includes("MintDividend") && (
                               <>

--- a/src/utils/getTokenTransactionHistory.js
+++ b/src/utils/getTokenTransactionHistory.js
@@ -50,6 +50,32 @@ export const getAllConfirmedSlpTxs = withSLP(async (SLP, slpAddresses, tokens) =
   return transactions;
 });
 
+const insert = (arr, index, newItem) => [...arr.slice(0, index), newItem, ...arr.slice(index)];
+
+const mockedBurnAll = txid => ({
+  txid,
+  detail: { transactionType: "BURN_ALL" },
+  vin: null,
+  vout: null,
+  balance: null,
+  confirmations: null,
+  date: null,
+  time: null
+});
+
+const mockedArrayBurnAll = txid => [
+  {
+    txid,
+    detail: { transactionType: "BURN_ALL" },
+    vin: null,
+    vout: null,
+    balance: null,
+    confirmations: null,
+    date: null,
+    time: null
+  }
+];
+
 const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtxos) => {
   try {
     const { tokenId } = tokenInfo;
@@ -255,7 +281,8 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
               }
 
               const remainingTxs = arrayUnconf.filter(
-                x => !accNoEmptyElements.reduce((a, b) => a.concat(b), []).includes(x)
+                x =>
+                  !accNoEmptyElements.reduce((a, b) => a.concat(b), []).some(e => e.txid === x.txid)
               );
               if (remainingTxs.length > 0) {
                 const remainingGenesis = remainingTxs.find(
@@ -289,22 +316,12 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                 }
               }
               if (accNoEmptyElements.length > 1) {
-                const mockedBurnAll = txid => [
-                  {
-                    txid,
-                    detail: { transactionType: "BURN_ALL" },
-                    vin: null,
-                    vout: null,
-                    balance: null,
-                    confirmations: null,
-                    date: null,
-                    time: null
-                  }
-                ];
                 const newLength = accNoEmptyElements.length * 2 - 1;
 
                 const accWithMockedBurnAll = Array.from({ length: newLength }).map((e, i) =>
-                  i % 2 === 0 ? accNoEmptyElements[i / 2] : mockedBurnAll(`unconf-${i}-burn-all`)
+                  i % 2 === 0
+                    ? accNoEmptyElements[i / 2]
+                    : mockedArrayBurnAll(`unconf-${i}-burn-all`)
                 );
                 return accWithMockedBurnAll.reduce((a, b) => a.concat(b), []);
               } else {
@@ -351,27 +368,11 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
               ) {
                 return { result: array, lastIndex: nextSentTxIndex };
               } else {
-                const insert = (arr, index, newItem) => [
-                  ...arr.slice(0, index),
-                  newItem,
-                  ...arr.slice(index)
-                ];
-
-                const mockedBurnAll = txid => ({
-                  txid,
-                  detail: { transactionType: "BURN_ALL" },
-                  vin: null,
-                  vout: null,
-                  balance: null,
-                  confirmations: null,
-                  date: null,
-                  time: null
-                });
                 const burnAllIndexes = array
                   .slice(0, nextSentTxIndex + 1)
                   .reduce((acc, cur, index) => {
                     if (
-                      !txIdInVin.includes(cur) &&
+                      !txIdInVin.some(e => e.txid === cur.txid) &&
                       cur.detail.transactionType !== "BURN_ALL" &&
                       cur.detail.transactionType !== "BURN_BATON"
                     ) {
@@ -412,20 +413,9 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
               ) {
                 return array.length > 1 ? { result: array, lastIndex: array.length - 1 } : array;
               } else {
-                const mockedBurnAll = txid => ({
-                  txid,
-                  detail: { transactionType: "BURN_ALL" },
-                  vin: null,
-                  vout: null,
-                  balance: null,
-                  confirmations: null,
-                  date: null,
-                  time: null
-                });
-
                 const burnAllIndexes = array.slice(0, array.length).reduce((acc, cur, index) => {
                   if (
-                    !txIdInVin.includes(cur) &&
+                    !txIdInVin.some(e => e.txid === cur.txid) &&
                     cur.detail.transactionType !== "BURN_ALL" &&
                     cur.detail.transactionType !== "BURN_BATON"
                   ) {
@@ -433,12 +423,6 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                   }
                   return acc;
                 }, []);
-
-                const insert = (arr, index, newItem) => [
-                  ...arr.slice(0, index),
-                  newItem,
-                  ...arr.slice(index)
-                ];
 
                 const slicedArrayWithBurnAllItems = burnAllIndexes.reduce((acc, cur, index) => {
                   return insert(acc, cur + index, mockedBurnAll(`unconf-${cur + index}-burn-all`));
@@ -670,7 +654,10 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                   }
 
                   const remainingTxs = concatDetails.filter(
-                    x => !accNoEmptyElements.reduce((a, b) => a.concat(b), []).includes(x)
+                    x =>
+                      !accNoEmptyElements
+                        .reduce((a, b) => a.concat(b), [])
+                        .some(e => e.txid === x.txid)
                   );
                   if (remainingTxs.length > 0) {
                     const remainingGenesis = remainingTxs.find(
@@ -704,24 +691,12 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                     }
                   }
                   if (accNoEmptyElements.length > 1) {
-                    const mockedBurnAll = txid => [
-                      {
-                        txid,
-                        detail: { transactionType: "BURN_ALL" },
-                        vin: null,
-                        vout: null,
-                        balance: null,
-                        confirmations: null,
-                        date: null,
-                        time: null
-                      }
-                    ];
                     const newLength = accNoEmptyElements.length * 2 - 1;
 
                     const accWithMockedBurnAll = Array.from({ length: newLength }).map((e, i) =>
                       i % 2 === 0
                         ? accNoEmptyElements[i / 2]
-                        : mockedBurnAll(`${concatDetailsIndex}-${i}-burn-all`)
+                        : mockedArrayBurnAll(`${concatDetailsIndex}-${i}-burn-all`)
                     );
                     return accWithMockedBurnAll.reduce((a, b) => a.concat(b), []);
                   } else {
@@ -746,6 +721,7 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                   el.detail.transactionType !== "BURN_BATON" &&
                   el.detail.transactionType !== "BURN_ALL")
             );
+
             if (nextSentTxIndex !== -1) {
               const lastUtxos = transactions.lastUnconfirmedSentTx
                 ? transactions.lastUnconfirmedSentTx.vin
@@ -764,39 +740,35 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                         item.vout > 0
                     ).length > 0
                 );
+
               if (
                 txIdInVin.length ===
-                array
-                  .slice(0, nextSentTxIndex + 1)
-                  .filter(
-                    el =>
-                      el.detail.transactionType !== "BURN_ALL" &&
-                      el.detail.transactionType !== "BURN_BATON"
-                  ).length
+                  array
+                    .slice(0, nextSentTxIndex + 1)
+                    .filter(
+                      el =>
+                        el.detail.transactionType !== "BURN_ALL" &&
+                        el.detail.transactionType !== "BURN_BATON"
+                    ).length &&
+                nextSentTxIndex !== 0
               ) {
                 return { result: array, lastIndex: nextSentTxIndex };
-              } else {
-                const insert = (arr, index, newItem) => [
-                  ...arr.slice(0, index),
-                  newItem,
-                  ...arr.slice(index)
-                ];
-
-                const mockedBurnAll = txid => ({
-                  txid,
-                  detail: { transactionType: "BURN_ALL" },
-                  vin: null,
-                  vout: null,
-                  balance: null,
-                  confirmations: null,
-                  date: null,
-                  time: null
-                });
+              } else if (
+                txIdInVin.length !==
+                  array
+                    .slice(0, nextSentTxIndex + 1)
+                    .filter(
+                      el =>
+                        el.detail.transactionType !== "BURN_ALL" &&
+                        el.detail.transactionType !== "BURN_BATON"
+                    ).length &&
+                nextSentTxIndex !== 0
+              ) {
                 const burnAllIndexes = array
                   .slice(0, nextSentTxIndex + 1)
                   .reduce((acc, cur, index) => {
                     if (
-                      !txIdInVin.includes(cur) &&
+                      !txIdInVin.some(e => e.txid === cur.txid) &&
                       cur.detail.transactionType !== "BURN_ALL" &&
                       cur.detail.transactionType !== "BURN_BATON"
                     ) {
@@ -808,7 +780,198 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                 const slicedArrayWithBurnAllItems = burnAllIndexes.reduce((acc, cur, index) => {
                   return insert(acc, cur + index, mockedBurnAll(`${cur + index}-burn-all`));
                 }, array);
+
                 return { result: slicedArrayWithBurnAllItems, lastIndex: nextSentTxIndex };
+              } else if (nextSentTxIndex === 0) {
+                const secondNextSentTx = array
+                  .slice(1, array.length)
+                  .find(
+                    el =>
+                      (el.balance > 0 && el.detail.transactionType === "BURN") ||
+                      (el.balance <= 0 &&
+                        el.detail.transactionType !== "BURN_BATON" &&
+                        el.detail.transactionType !== "BURN_ALL")
+                  );
+
+                const secondNextSentTxIndex = array
+                  .slice(1, array.length)
+                  .findIndex(
+                    el =>
+                      (el.balance > 0 && el.detail.transactionType === "BURN") ||
+                      (el.balance <= 0 &&
+                        el.detail.transactionType !== "BURN_BATON" &&
+                        el.detail.transactionType !== "BURN_ALL")
+                  );
+
+                const isBurAllLastTx =
+                  txIdInVin.length !==
+                  array
+                    .slice(0, nextSentTxIndex + 1)
+                    .filter(
+                      el =>
+                        el.detail.transactionType !== "BURN_ALL" &&
+                        el.detail.transactionType !== "BURN_BATON"
+                    ).length;
+
+                if (
+                  !isBurAllLastTx &&
+                  secondNextSentTxIndex !== -1 &&
+                  secondNextSentTx.time === array[0].time
+                ) {
+                  return { result: array, lastIndex: secondNextSentTxIndex + 1 };
+                } else if (
+                  isBurAllLastTx &&
+                  secondNextSentTxIndex !== -1 &&
+                  secondNextSentTx.time === array[0].time
+                ) {
+                  const burnAllIndexes = array
+                    .slice(0, nextSentTxIndex + 1)
+                    .reduce((acc, cur, index) => {
+                      if (
+                        !txIdInVin.some(e => e.txid === cur.txid) &&
+                        cur.detail.transactionType !== "BURN_ALL" &&
+                        cur.detail.transactionType !== "BURN_BATON"
+                      ) {
+                        acc.push(index);
+                      }
+                      return acc;
+                    }, []);
+
+                  const slicedArrayWithBurnAllItems = burnAllIndexes.reduce((acc, cur, index) => {
+                    return insert(acc, cur + index, mockedBurnAll(`${cur + index}-burn-all`));
+                  }, array);
+
+                  return {
+                    result: slicedArrayWithBurnAllItems,
+                    lastIndex: secondNextSentTxIndex + 1
+                  };
+                } else if (secondNextSentTxIndex === -1) {
+                  const txIdInFirstSentVin = array
+                    .slice(1, array.length)
+                    .filter(
+                      el =>
+                        el.detail.transactionType !== "BURN_ALL" &&
+                        el.detail.transactionType !== "BURN_BATON" &&
+                        array[0].vin.filter(
+                          item =>
+                            item.txid === el.txid &&
+                            item.vout <= el.detail.outputs.length &&
+                            item.vout > 0
+                        ).length > 0
+                    );
+
+                  if (
+                    txIdInFirstSentVin.length ===
+                    array
+                      .slice(1, array.length)
+                      .filter(
+                        el =>
+                          el.detail.transactionType !== "BURN_ALL" &&
+                          el.detail.transactionType !== "BURN_BATON"
+                      ).length
+                  ) {
+                    return array.length > 1
+                      ? {
+                          result: isBurAllLastTx
+                            ? insert(array, 0, mockedBurnAll(`0-burn-all`))
+                            : array,
+                          lastIndex: array.length - 1
+                        }
+                      : array;
+                  } else {
+                    const burnAllIndexes = array
+                      .slice(1, array.length)
+                      .reduce((acc, cur, index) => {
+                        if (
+                          !txIdInFirstSentVin.some(e => e.txid === cur.txid) &&
+                          cur.detail.transactionType !== "BURN_ALL" &&
+                          cur.detail.transactionType !== "BURN_BATON"
+                        ) {
+                          acc.push(index + 1);
+                        }
+                        return acc;
+                      }, []);
+
+                    const slicedArrayWithBurnAllItems = burnAllIndexes.reduce((acc, cur, index) => {
+                      return insert(acc, cur + index, mockedBurnAll(`${cur + index}-burn-all`));
+                    }, array);
+                    return {
+                      result: isBurAllLastTx
+                        ? insert(slicedArrayWithBurnAllItems, 0, mockedBurnAll(`0-burn-all`))
+                        : slicedArrayWithBurnAllItems,
+                      lastIndex: array.length - 1
+                    };
+                  }
+                } else if (
+                  secondNextSentTxIndex !== -1 &&
+                  secondNextSentTx.time !== array[0].time
+                ) {
+                  const txIdInFirstSentVin = array
+                    .slice(1, secondNextSentTxIndex + 1)
+                    .filter(
+                      el =>
+                        el.detail.transactionType !== "BURN_ALL" &&
+                        el.detail.transactionType !== "BURN_BATON" &&
+                        array[0].vin.filter(
+                          item =>
+                            item.txid === el.txid &&
+                            item.vout <= el.detail.outputs.length &&
+                            item.vout > 0
+                        ).length > 0
+                    );
+
+                  if (
+                    txIdInFirstSentVin.length ===
+                    array
+                      .slice(1, secondNextSentTxIndex + 1)
+                      .filter(
+                        el =>
+                          el.detail.transactionType !== "BURN_ALL" &&
+                          el.detail.transactionType !== "BURN_BATON"
+                      ).length
+                  ) {
+                    return {
+                      result: isBurAllLastTx
+                        ? insert(array, 0, mockedBurnAll(`0-burn-all`))
+                        : array,
+                      lastIndex: secondNextSentTxIndex + 1
+                    };
+                  } else {
+                    const burnAllIndexes = array
+                      .slice(1, secondNextSentTxIndex + 1)
+                      .reduce((acc, cur, itemIndex) => {
+                        if (
+                          !txIdInFirstSentVin.some(e => e.txid === cur.txid) &&
+                          cur.detail.transactionType !== "BURN_ALL" &&
+                          cur.detail.transactionType !== "BURN_BATON"
+                        ) {
+                          acc.push(itemIndex + 1);
+                        }
+                        return acc;
+                      }, []);
+
+                    const slicedArrayWithBurnAllItems = burnAllIndexes.reduce(
+                      (accItem, curItem, itemIndex) => {
+                        return insert(
+                          accItem,
+                          curItem + itemIndex,
+                          mockedBurnAll(`${curItem + itemIndex}-burn-all`)
+                        );
+                      },
+                      array
+                    );
+                    return {
+                      result: isBurAllLastTx
+                        ? insert(slicedArrayWithBurnAllItems, 0, mockedBurnAll(`0-burn-all`))
+                        : slicedArrayWithBurnAllItems,
+                      lastIndex: secondNextSentTxIndex + 1
+                    };
+                  }
+                } else {
+                  return { result: array, lastIndex: array.length - 1 };
+                }
+              } else {
+                return { result: array, lastIndex: array.length - 1 };
               }
             } else {
               const lastUtxos = transactions.lastUnconfirmedSentTx
@@ -841,20 +1004,9 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
               ) {
                 return array.length > 1 ? { result: array, lastIndex: array.length - 1 } : array;
               } else {
-                const mockedBurnAll = txid => ({
-                  txid,
-                  detail: { transactionType: "BURN_ALL" },
-                  vin: null,
-                  vout: null,
-                  balance: null,
-                  confirmations: null,
-                  date: null,
-                  time: null
-                });
-
                 const burnAllIndexes = array.slice(0, array.length).reduce((acc, cur, index) => {
                   if (
-                    !txIdInVin.includes(cur) &&
+                    !txIdInVin.some(e => e.txid === cur.txid) &&
                     cur.detail.transactionType !== "BURN_ALL" &&
                     cur.detail.transactionType !== "BURN_BATON"
                   ) {
@@ -862,12 +1014,6 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                   }
                   return acc;
                 }, []);
-
-                const insert = (arr, index, newItem) => [
-                  ...arr.slice(0, index),
-                  newItem,
-                  ...arr.slice(index)
-                ];
 
                 const slicedArrayWithBurnAllItems = burnAllIndexes.reduce((acc, cur, index) => {
                   return insert(acc, cur + index, mockedBurnAll(`${cur + index}-burn-all`));
@@ -903,7 +1049,7 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
 
               if (nextSentTxIndex !== -1 && nextSentTx.time !== array[acc.lastIndex].time) {
                 const txIdInVin = array
-                  .slice(index + 1, nextSentTxIndex + 1)
+                  .slice(index + 1, nextSentTxIndex + index + 2)
                   .filter(
                     el =>
                       el.detail.transactionType !== "BURN_ALL" &&
@@ -919,36 +1065,24 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                 if (
                   txIdInVin.length ===
                   array
-                    .slice(index + 1, nextSentTxIndex + 1)
+                    .slice(index + 1, nextSentTxIndex + index + 2)
                     .filter(
                       el =>
                         el.detail.transactionType !== "BURN_ALL" &&
                         el.detail.transactionType !== "BURN_BATON"
                     ).length
                 ) {
-                  return { result: acc.result, lastIndex: nextSentTxIndex };
+                  return { result: acc.result, lastIndex: nextSentTxIndex + index + 1 };
                 } else {
-                  const insert = (arr, index, newItem) => [
-                    ...arr.slice(0, index),
-                    newItem,
-                    ...arr.slice(index)
-                  ];
+                  const numberBurnAlls =
+                    acc.result.filter(e => e.detail.transactionType === "BURN_ALL").length -
+                    array.filter(e => e.detail.transactionType === "BURN_ALL").length;
 
-                  const mockedBurnAll = txid => ({
-                    txid,
-                    detail: { transactionType: "BURN_ALL" },
-                    vin: null,
-                    vout: null,
-                    balance: null,
-                    confirmations: null,
-                    date: null,
-                    time: null
-                  });
                   const burnAllIndexes = array
-                    .slice(index + 1, nextSentTxIndex + 1)
+                    .slice(index + 1, nextSentTxIndex + index + 2)
                     .reduce((acc, cur, itemIndex) => {
                       if (
-                        !txIdInVin.includes(cur) &&
+                        !txIdInVin.some(e => e.txid === cur.txid) &&
                         cur.detail.transactionType !== "BURN_ALL" &&
                         cur.detail.transactionType !== "BURN_BATON"
                       ) {
@@ -956,18 +1090,20 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                       }
                       return acc;
                     }, []);
-
                   const slicedArrayWithBurnAllItems = burnAllIndexes.reduce(
                     (accItem, curItem, itemIndex) => {
                       return insert(
                         accItem,
-                        curItem + itemIndex,
+                        curItem + itemIndex + numberBurnAlls,
                         mockedBurnAll(`${curItem + itemIndex}-burn-all`)
                       );
                     },
                     acc.result
                   );
-                  return { result: slicedArrayWithBurnAllItems, lastIndex: nextSentTxIndex };
+                  return {
+                    result: slicedArrayWithBurnAllItems,
+                    lastIndex: nextSentTxIndex + index + 1
+                  };
                 }
               } else {
                 const txIdInVin = array
@@ -996,26 +1132,9 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                 ) {
                   return { result: acc.result, lastIndex: array.length - 1 };
                 } else {
-                  const insert = (arr, index, newItem) => [
-                    ...arr.slice(0, index),
-                    newItem,
-                    ...arr.slice(index)
-                  ];
-
-                  const mockedBurnAll = txid => ({
-                    txid,
-                    detail: { transactionType: "BURN_ALL" },
-                    vin: null,
-                    vout: null,
-                    balance: null,
-                    confirmations: null,
-                    date: null,
-                    time: null
-                  });
-
                   const burnAllIndexes = array.slice(index + 1).reduce((acc, cur, itemIndex) => {
                     if (
-                      !txIdInVin.includes(cur) &&
+                      !txIdInVin.some(e => e.txid === cur.txid) &&
                       cur.detail.transactionType !== "BURN_ALL" &&
                       cur.detail.transactionType !== "BURN_BATON"
                     ) {
@@ -1024,11 +1143,15 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtx
                     return acc;
                   }, []);
 
+                  const numberBurnAlls =
+                    acc.result.filter(e => e.detail.transactionType === "BURN_ALL").length -
+                    array.filter(e => e.detail.transactionType === "BURN_ALL").length;
+
                   const slicedArrayWithBurnAllItems = burnAllIndexes.reduce(
                     (accItem, curItem, itemIndex) => {
                       return insert(
                         accItem,
-                        curItem + itemIndex,
+                        curItem + itemIndex + numberBurnAlls,
                         mockedBurnAll(`${curItem + itemIndex}-burn-all`)
                       );
                     },

--- a/src/utils/getTokenTransactionHistory.js
+++ b/src/utils/getTokenTransactionHistory.js
@@ -50,7 +50,7 @@ export const getAllConfirmedSlpTxs = withSLP(async (SLP, slpAddresses, tokens) =
   return transactions;
 });
 
-const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo) => {
+const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo, tokenUtxos) => {
   try {
     const { tokenId } = tokenInfo;
 
@@ -77,7 +77,8 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo) => {
 
     const tokenTransactionHistory = {
       confirmed: [],
-      unconfirmed: []
+      unconfirmed: [],
+      lastUnconfirmedSentTx: null
     };
 
     const unconfirmedTxs = await getUnconfirmedTxs(slpAddresses);
@@ -90,6 +91,8 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo) => {
         .map(txidDetail => ({
           txid: txidDetail.txid,
           detail: txidDetail.tokenDetails,
+          vin: txidDetail.vin,
+          vout: txidDetail.vout,
           balance: calculateTransactionBalance(txidDetail.tokenDetails.outputs),
           confirmations: 0,
           date: new Date()
@@ -99,17 +102,380 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo) => {
             return (
               +(x.detail.transactionType === "GENESIS") - +(y.detail.transactionType === "GENESIS")
             );
-          }
-          if (
-            Xor(x.detail.transactionType === "MINT", y.detail.transactionType === "MINT") &&
-            x.detail.transactionType !== "GENESIS" &&
-            y.detail.transactionType !== "GENESIS"
-          ) {
-            return +(x.detail.transactionType === "MINT") - +(y.detail.transactionType === "MINT");
           } else {
             return 1;
           }
+        })
+        .map(txDetail => {
+          if (
+            txDetail.detail.transactionType === "SEND" &&
+            txDetail.detail.outputs.length === 1 &&
+            slpAddresses.includes(txDetail.detail.outputs[0].address)
+          ) {
+            return { ...txDetail, detail: { ...txDetail.detail, transactionType: "BURN" } };
+          } else {
+            return txDetail;
+          }
+        })
+        .map(txDetail => {
+          if (txDetail.detail.transactionType === "MINT" && txDetail.balance === 0) {
+            return { ...txDetail, detail: { ...txDetail.detail, transactionType: "BURN_BATON" } };
+          } else {
+            return txDetail;
+          }
         });
+
+      const burnTxs = tokenTransactionHistory.unconfirmed.filter(
+        txDetail => txDetail.detail.transactionType === "BURN"
+      );
+
+      if (burnTxs.length > 0) {
+        const revertChunk = chunkedArray =>
+          chunkedArray.reduce((unchunkedArray, chunk) => [...unchunkedArray, ...chunk], []);
+        const burnTxIds = burnTxs.map(txDetail => txDetail.txid);
+        const txIdChunks = chunk(burnTxIds, 20);
+        const amounts = revertChunk(
+          await Promise.all(txIdChunks.map(txIdChunk => SLP.Utils.burnTotal(txIdChunk)))
+        );
+        tokenTransactionHistory.unconfirmed = tokenTransactionHistory.unconfirmed.map(txDetail =>
+          txDetail.detail.transactionType === "BURN"
+            ? {
+                ...txDetail,
+                detail: {
+                  ...txDetail.detail,
+                  burnAmount: (amounts.find(amount => amount.transactionId === txDetail.txid) || {})
+                    .burnTotal
+                }
+              }
+            : txDetail
+        );
+      }
+
+      if (tokenTransactionHistory.unconfirmed.length > 1) {
+        const sentTxs = tokenTransactionHistory.unconfirmed.filter(
+          el =>
+            (el.balance > 0 && el.detail.transactionType === "BURN") ||
+            (el.balance <= 0 && el.detail.transactionType !== "BURN_BATON")
+        );
+
+        if (sentTxs.length > 0) {
+          const arrayUnconf = tokenTransactionHistory.unconfirmed;
+          tokenTransactionHistory.unconfirmed = sentTxs.reduce((acc, cur, index, array) => {
+            acc[index] = [];
+            const vin = cur.vin;
+            const txIdInVin = arrayUnconf.filter(
+              el =>
+                vin.filter(
+                  item =>
+                    item.txid === el.txid && item.vout <= el.detail.outputs.length && item.vout > 0
+                ).length > 0 &&
+                el.txid !== cur.txid &&
+                el.detail.transactionType !== "BURN_BATON"
+            );
+
+            if (txIdInVin.length > 0) {
+              const hasSentTx = txIdInVin.findIndex(
+                el =>
+                  (el.balance > 0 && el.detail.transactionType === "BURN") ||
+                  (el.balance <= 0 && el.detail.transactionType !== "BURN_BATON")
+              );
+              if (hasSentTx !== -1 && hasSentTx !== txIdInVin.length - 1) {
+                const sentTx = txIdInVin[hasSentTx];
+                txIdInVin[hasSentTx] = txIdInVin[txIdInVin.length - 1];
+                txIdInVin[txIdInVin.length - 1] = sentTx;
+              }
+
+              const isCurrentElementAlreadyOnAccIndex = acc.findIndex(
+                accElArr => accElArr.findIndex(accEl => accEl.txid === cur.txid) !== -1
+              );
+              const isCurrentElementAlreadyOnAcc = isCurrentElementAlreadyOnAccIndex !== -1;
+              const currentElementHasSentTxInVinIndex = acc.findIndex(
+                accElArr =>
+                  accElArr.findIndex(
+                    accEl => accEl.txid === txIdInVin[txIdInVin.length - 1].txid
+                  ) !== -1
+              );
+              const currentElementHasSentTxInVin =
+                hasSentTx !== -1 && currentElementHasSentTxInVinIndex !== -1;
+
+              if (isCurrentElementAlreadyOnAcc && currentElementHasSentTxInVin) {
+                acc[isCurrentElementAlreadyOnAccIndex] = acc[isCurrentElementAlreadyOnAccIndex]
+                  .concat(txIdInVin.slice(0, txIdInVin.length - 1))
+                  .concat(acc[currentElementHasSentTxInVinIndex]);
+                acc[currentElementHasSentTxInVinIndex] = [];
+              }
+
+              if (isCurrentElementAlreadyOnAcc && !currentElementHasSentTxInVin) {
+                acc[isCurrentElementAlreadyOnAccIndex] = acc[
+                  isCurrentElementAlreadyOnAccIndex
+                ].concat(txIdInVin);
+              }
+
+              if (!isCurrentElementAlreadyOnAcc && currentElementHasSentTxInVin) {
+                acc[index].push(cur);
+                acc[index] = acc[index].concat(txIdInVin.slice(0, txIdInVin.length - 1));
+                acc[index] = acc[index].concat(acc[currentElementHasSentTxInVinIndex]);
+                acc[currentElementHasSentTxInVinIndex] = [];
+              }
+
+              if (!isCurrentElementAlreadyOnAcc && !currentElementHasSentTxInVin) {
+                acc[index].push(cur);
+
+                acc[index] = acc[index].concat(txIdInVin);
+              }
+            } else {
+              const isCurrentElementAlreadyOnAccIndex = acc.findIndex(
+                accElArr => accElArr.findIndex(accEl => accEl.txid === cur.txid) !== -1
+              );
+              const isCurrentElementAlreadyOnAcc = isCurrentElementAlreadyOnAccIndex !== -1;
+              if (!isCurrentElementAlreadyOnAcc) {
+                acc[index].push(cur);
+              }
+            }
+
+            if (index < array.length - 1) {
+              return acc;
+            } else {
+              const accNoEmptyElements = acc.filter(el => !(Array.isArray(el) && el.length === 0));
+              const burnBatonTx = arrayUnconf.find(
+                el => el.detail.transactionType === "BURN_BATON"
+              );
+              if (burnBatonTx) {
+                accNoEmptyElements[0].unshift(burnBatonTx);
+              }
+
+              const genesisTxIndex = accNoEmptyElements.findIndex(
+                elArr => elArr.findIndex(el => el.detail.transactionType === "GENESIS") !== -1
+              );
+              if (genesisTxIndex !== -1 && genesisTxIndex !== accNoEmptyElements.length - 1) {
+                const lastItem = accNoEmptyElements[accNoEmptyElements.length - 1];
+                const genesisTx = accNoEmptyElements[genesisTxIndex];
+                accNoEmptyElements[genesisTxIndex] = lastItem;
+                accNoEmptyElements[accNoEmptyElements.length - 1] = genesisTx;
+              }
+
+              const remainingTxs = arrayUnconf.filter(
+                x => !accNoEmptyElements.reduce((a, b) => a.concat(b), []).includes(x)
+              );
+              if (remainingTxs.length > 0) {
+                const remainingGenesis = remainingTxs.find(
+                  el => el.detail.transactionType === "GENESIS"
+                );
+                if (burnBatonTx && remainingGenesis) {
+                  accNoEmptyElements.push([remainingGenesis]);
+                  accNoEmptyElements[0] = [
+                    burnBatonTx,
+                    ...remainingTxs.filter(el => el.detail.transactionType !== "GENESIS"),
+                    ...accNoEmptyElements[0].slice(1)
+                  ];
+                }
+                if (!burnBatonTx && remainingGenesis) {
+                  accNoEmptyElements.push([remainingGenesis]);
+                  accNoEmptyElements[0] = [
+                    ...remainingTxs.filter(el => el.detail.transactionType !== "GENESIS"),
+                    ...accNoEmptyElements[0]
+                  ];
+                }
+                if (burnBatonTx && !remainingGenesis) {
+                  accNoEmptyElements[0] = [
+                    burnBatonTx,
+                    ...remainingTxs,
+                    ...accNoEmptyElements[0].slice(1)
+                  ];
+                }
+
+                if (!burnBatonTx && !remainingGenesis) {
+                  accNoEmptyElements[0] = [...remainingTxs, ...accNoEmptyElements[0]];
+                }
+              }
+              if (accNoEmptyElements.length > 1) {
+                const mockedBurnAll = txid => [
+                  {
+                    txid,
+                    detail: { transactionType: "BURN_ALL" },
+                    vin: null,
+                    vout: null,
+                    balance: null,
+                    confirmations: null,
+                    date: null,
+                    time: null
+                  }
+                ];
+                const newLength = accNoEmptyElements.length * 2 - 1;
+
+                const accWithMockedBurnAll = Array.from({ length: newLength }).map((e, i) =>
+                  i % 2 === 0 ? accNoEmptyElements[i / 2] : mockedBurnAll(`unconf-${i}-burn-all`)
+                );
+                return accWithMockedBurnAll.reduce((a, b) => a.concat(b), []);
+              } else {
+                return accNoEmptyElements.reduce((a, b) => a.concat(b), []);
+              }
+            }
+          }, []);
+        }
+      }
+
+      tokenTransactionHistory.unconfirmed = tokenTransactionHistory.unconfirmed
+        .reduce((acc, cur, index, array) => {
+          if (index === 0) {
+            const nextSentTxIndex = array.findIndex(
+              el =>
+                (el.balance > 0 && el.detail.transactionType === "BURN") ||
+                (el.balance <= 0 &&
+                  el.detail.transactionType !== "BURN_BATON" &&
+                  el.detail.transactionType !== "BURN_ALL")
+            );
+            if (nextSentTxIndex !== -1) {
+              const txIdInVin = array
+                .slice(0, nextSentTxIndex + 1)
+                .filter(
+                  el =>
+                    el.detail.transactionType !== "BURN_ALL" &&
+                    el.detail.transactionType !== "BURN_BATON" &&
+                    tokenUtxos.filter(
+                      item =>
+                        item.txid === el.txid &&
+                        item.vout <= el.detail.outputs.length &&
+                        item.vout > 0
+                    ).length > 0
+                );
+              if (
+                txIdInVin.length ===
+                array
+                  .slice(0, nextSentTxIndex + 1)
+                  .filter(
+                    el =>
+                      el.detail.transactionType !== "BURN_ALL" &&
+                      el.detail.transactionType !== "BURN_BATON"
+                  ).length
+              ) {
+                return { result: array, lastIndex: nextSentTxIndex };
+              } else {
+                const insert = (arr, index, newItem) => [
+                  ...arr.slice(0, index),
+                  newItem,
+                  ...arr.slice(index)
+                ];
+
+                const mockedBurnAll = txid => ({
+                  txid,
+                  detail: { transactionType: "BURN_ALL" },
+                  vin: null,
+                  vout: null,
+                  balance: null,
+                  confirmations: null,
+                  date: null,
+                  time: null
+                });
+                const burnAllIndexes = array
+                  .slice(0, nextSentTxIndex + 1)
+                  .reduce((acc, cur, index) => {
+                    if (
+                      !txIdInVin.includes(cur) &&
+                      cur.detail.transactionType !== "BURN_ALL" &&
+                      cur.detail.transactionType !== "BURN_BATON"
+                    ) {
+                      acc.push(index);
+                    }
+                    return acc;
+                  }, []);
+
+                const slicedArrayWithBurnAllItems = burnAllIndexes.reduce((acc, cur, index) => {
+                  return insert(acc, cur + index, mockedBurnAll(`unconf-${cur + index}-burn-all`));
+                }, array);
+                return { result: slicedArrayWithBurnAllItems, lastIndex: nextSentTxIndex };
+              }
+            } else {
+              const txIdInVin = array
+                .slice(0, array.length)
+                .filter(
+                  el =>
+                    el.detail.transactionType !== "BURN_ALL" &&
+                    el.detail.transactionType !== "BURN_BATON" &&
+                    tokenUtxos.filter(
+                      item =>
+                        item.txid === el.txid &&
+                        item.vout <= el.detail.outputs.length &&
+                        item.vout > 0
+                    ).length > 0
+                );
+
+              if (
+                txIdInVin.length ===
+                array
+                  .slice(0, array.length)
+                  .filter(
+                    el =>
+                      el.detail.transactionType !== "BURN_ALL" &&
+                      el.detail.transactionType !== "BURN_BATON"
+                  ).length
+              ) {
+                return array.length > 1 ? { result: array, lastIndex: array.length - 1 } : array;
+              } else {
+                const mockedBurnAll = txid => ({
+                  txid,
+                  detail: { transactionType: "BURN_ALL" },
+                  vin: null,
+                  vout: null,
+                  balance: null,
+                  confirmations: null,
+                  date: null,
+                  time: null
+                });
+
+                const burnAllIndexes = array.slice(0, array.length).reduce((acc, cur, index) => {
+                  if (
+                    !txIdInVin.includes(cur) &&
+                    cur.detail.transactionType !== "BURN_ALL" &&
+                    cur.detail.transactionType !== "BURN_BATON"
+                  ) {
+                    acc.push(index);
+                  }
+                  return acc;
+                }, []);
+
+                const insert = (arr, index, newItem) => [
+                  ...arr.slice(0, index),
+                  newItem,
+                  ...arr.slice(index)
+                ];
+
+                const slicedArrayWithBurnAllItems = burnAllIndexes.reduce((acc, cur, index) => {
+                  return insert(acc, cur + index, mockedBurnAll(`unconf-${cur + index}-burn-all`));
+                }, array);
+                return { result: slicedArrayWithBurnAllItems, lastIndex: array.length - 1 };
+              }
+            }
+          } else {
+            if (index === array.length - 1) {
+              return acc.result;
+            } else {
+              return acc;
+            }
+          }
+        }, [])
+        .filter(
+          (tx, index, array) =>
+            !(
+              tx.detail.transactionType === "BURN_ALL" &&
+              array.length > 1 &&
+              array[index + 1].detail.transactionType === "SEND" &&
+              array[index + 1].detail.outputs.length &&
+              array[index + 1].detail.outputs.findIndex(output =>
+                slpAddresses.includes(output.address)
+              ) === -1
+            )
+        );
+      tokenTransactionHistory.lastUnconfirmedSentTx = tokenTransactionHistory.unconfirmed
+        .slice()
+        .reverse()
+        .find(
+          el =>
+            (el.balance > 0 && el.detail.transactionType === "BURN") ||
+            (el.balance <= 0 &&
+              el.detail.transactionType !== "BURN_BATON" &&
+              el.detail.transactionType !== "BURN_ALL")
+        );
     }
 
     const remainingNumberTxsDetails = 30 - tokenTransactionHistory.unconfirmed.length;
@@ -140,6 +506,8 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo) => {
           txid: txidDetail.txid,
           detail: concatenatedTransactions.find(el => el.txid === txidDetail.txid).tokenDetails
             .detail,
+          vin: txidDetail.vin,
+          vout: txidDetail.vout,
           balance: calculateTransactionBalance(
             concatenatedTransactions.find(el => el.txid === txidDetail.txid).tokenDetails.detail
               .outputs
@@ -154,21 +522,568 @@ const getTokenTransactionHistory = async (SLP, slpAddresses, tokenInfo) => {
               +(x.detail.transactionType === "GENESIS") - +(y.detail.transactionType === "GENESIS")
             );
           }
-          if (
-            y.time === x.time &&
-            Xor(x.detail.transactionType === "MINT", y.detail.transactionType === "MINT") &&
-            x.detail.transactionType !== "GENESIS" &&
-            y.detail.transactionType !== "GENESIS"
-          ) {
-            return +(x.detail.transactionType === "MINT") - +(y.detail.transactionType === "MINT");
-          }
           if (y.time === x.time) {
-            return 1;
+            return -1;
           } else {
             return y.time - x.time;
           }
         })
-        .slice(0, remainingNumberTxsDetails);
+        .slice(0, remainingNumberTxsDetails)
+        .map(txDetail => {
+          if (
+            txDetail.detail.transactionType === "SEND" &&
+            txDetail.detail.outputs.length === 1 &&
+            slpAddresses.includes(txDetail.detail.outputs[0].address)
+          ) {
+            return { ...txDetail, detail: { ...txDetail.detail, transactionType: "BURN" } };
+          } else {
+            return txDetail;
+          }
+        })
+        .map(txDetail => {
+          if (txDetail.detail.transactionType === "MINT" && txDetail.balance === 0) {
+            return { ...txDetail, detail: { ...txDetail.detail, transactionType: "BURN_BATON" } };
+          } else {
+            return txDetail;
+          }
+        })
+        .reduce((acc, cur, index, array) => {
+          acc[index] = [];
+          if (
+            (index > 0 && cur.time === array[index - 1].time) ||
+            (index < array.length - 1 && cur.time === array[index + 1].time)
+          ) {
+            const fisrtOcur = array.findIndex(el => el.time === cur.time);
+            acc[fisrtOcur].push(cur);
+          } else {
+            acc[index] = cur;
+          }
+          return index < array.length - 1
+            ? acc
+            : acc.filter(el => !(Array.isArray(el) && el.length === 0));
+        }, [])
+        .map((concatDetails, concatDetailsIndex) => {
+          if (Array.isArray(concatDetails)) {
+            const sentTxs = concatDetails.filter(
+              el =>
+                (el.balance > 0 && el.detail.transactionType === "BURN") ||
+                (el.balance <= 0 && el.detail.transactionType !== "BURN_BATON")
+            );
+
+            if (sentTxs.length > 0) {
+              return sentTxs.reduce((acc, cur, index, array) => {
+                acc[index] = [];
+                const vin = cur.vin;
+                const txIdInVin = concatDetails.filter(
+                  el =>
+                    vin.filter(
+                      item =>
+                        item.txid === el.txid &&
+                        item.vout <= el.detail.outputs.length &&
+                        item.vout > 0
+                    ).length > 0 &&
+                    el.txid !== cur.txid &&
+                    el.detail.transactionType !== "BURN_BATON"
+                );
+
+                if (txIdInVin.length > 0) {
+                  const hasSentTx = txIdInVin.findIndex(
+                    el =>
+                      (el.balance > 0 && el.detail.transactionType === "BURN") ||
+                      (el.balance <= 0 && el.detail.transactionType !== "BURN_BATON")
+                  );
+                  if (hasSentTx !== -1 && hasSentTx !== txIdInVin.length - 1) {
+                    const sentTx = txIdInVin[hasSentTx];
+                    txIdInVin[hasSentTx] = txIdInVin[txIdInVin.length - 1];
+                    txIdInVin[txIdInVin.length - 1] = sentTx;
+                  }
+
+                  const isCurrentElementAlreadyOnAccIndex = acc.findIndex(
+                    accElArr => accElArr.findIndex(accEl => accEl.txid === cur.txid) !== -1
+                  );
+                  const isCurrentElementAlreadyOnAcc = isCurrentElementAlreadyOnAccIndex !== -1;
+                  const currentElementHasSentTxInVinIndex = acc.findIndex(
+                    accElArr =>
+                      accElArr.findIndex(
+                        accEl => accEl.txid === txIdInVin[txIdInVin.length - 1].txid
+                      ) !== -1
+                  );
+                  const currentElementHasSentTxInVin =
+                    hasSentTx !== -1 && currentElementHasSentTxInVinIndex !== -1;
+
+                  if (isCurrentElementAlreadyOnAcc && currentElementHasSentTxInVin) {
+                    acc[isCurrentElementAlreadyOnAccIndex] = acc[isCurrentElementAlreadyOnAccIndex]
+                      .concat(txIdInVin.slice(0, txIdInVin.length - 1))
+                      .concat(acc[currentElementHasSentTxInVinIndex]);
+                    acc[currentElementHasSentTxInVinIndex] = [];
+                  }
+
+                  if (isCurrentElementAlreadyOnAcc && !currentElementHasSentTxInVin) {
+                    acc[isCurrentElementAlreadyOnAccIndex] = acc[
+                      isCurrentElementAlreadyOnAccIndex
+                    ].concat(txIdInVin);
+                  }
+
+                  if (!isCurrentElementAlreadyOnAcc && currentElementHasSentTxInVin) {
+                    acc[index].push(cur);
+                    acc[index] = acc[index].concat(txIdInVin.slice(0, txIdInVin.length - 1));
+                    acc[index] = acc[index].concat(acc[currentElementHasSentTxInVinIndex]);
+                    acc[currentElementHasSentTxInVinIndex] = [];
+                  }
+
+                  if (!isCurrentElementAlreadyOnAcc && !currentElementHasSentTxInVin) {
+                    acc[index].push(cur);
+
+                    acc[index] = acc[index].concat(txIdInVin);
+                  }
+                } else {
+                  const isCurrentElementAlreadyOnAccIndex = acc.findIndex(
+                    accElArr => accElArr.findIndex(accEl => accEl.txid === cur.txid) !== -1
+                  );
+                  const isCurrentElementAlreadyOnAcc = isCurrentElementAlreadyOnAccIndex !== -1;
+                  if (!isCurrentElementAlreadyOnAcc) {
+                    acc[index].push(cur);
+                  }
+                }
+
+                if (index < array.length - 1) {
+                  return acc;
+                } else {
+                  const accNoEmptyElements = acc.filter(
+                    el => !(Array.isArray(el) && el.length === 0)
+                  );
+                  const burnBatonTx = concatDetails.find(
+                    el => el.detail.transactionType === "BURN_BATON"
+                  );
+                  if (burnBatonTx) {
+                    accNoEmptyElements[0].unshift(burnBatonTx);
+                  }
+
+                  const genesisTxIndex = accNoEmptyElements.findIndex(
+                    elArr => elArr.findIndex(el => el.detail.transactionType === "GENESIS") !== -1
+                  );
+                  if (genesisTxIndex !== -1 && genesisTxIndex !== accNoEmptyElements.length - 1) {
+                    const lastItem = accNoEmptyElements[accNoEmptyElements.length - 1];
+                    const genesisTx = accNoEmptyElements[genesisTxIndex];
+                    accNoEmptyElements[genesisTxIndex] = lastItem;
+                    accNoEmptyElements[accNoEmptyElements.length - 1] = genesisTx;
+                  }
+
+                  const remainingTxs = concatDetails.filter(
+                    x => !accNoEmptyElements.reduce((a, b) => a.concat(b), []).includes(x)
+                  );
+                  if (remainingTxs.length > 0) {
+                    const remainingGenesis = remainingTxs.find(
+                      el => el.detail.transactionType === "GENESIS"
+                    );
+                    if (burnBatonTx && remainingGenesis) {
+                      accNoEmptyElements.push([remainingGenesis]);
+                      accNoEmptyElements[0] = [
+                        burnBatonTx,
+                        ...remainingTxs.filter(el => el.detail.transactionType !== "GENESIS"),
+                        ...accNoEmptyElements[0].slice(1)
+                      ];
+                    }
+                    if (!burnBatonTx && remainingGenesis) {
+                      accNoEmptyElements.push([remainingGenesis]);
+                      accNoEmptyElements[0] = [
+                        ...remainingTxs.filter(el => el.detail.transactionType !== "GENESIS"),
+                        ...accNoEmptyElements[0]
+                      ];
+                    }
+                    if (burnBatonTx && !remainingGenesis) {
+                      accNoEmptyElements[0] = [
+                        burnBatonTx,
+                        ...remainingTxs,
+                        ...accNoEmptyElements[0].slice(1)
+                      ];
+                    }
+
+                    if (!burnBatonTx && !remainingGenesis) {
+                      accNoEmptyElements[0] = [...remainingTxs, ...accNoEmptyElements[0]];
+                    }
+                  }
+                  if (accNoEmptyElements.length > 1) {
+                    const mockedBurnAll = txid => [
+                      {
+                        txid,
+                        detail: { transactionType: "BURN_ALL" },
+                        vin: null,
+                        vout: null,
+                        balance: null,
+                        confirmations: null,
+                        date: null,
+                        time: null
+                      }
+                    ];
+                    const newLength = accNoEmptyElements.length * 2 - 1;
+
+                    const accWithMockedBurnAll = Array.from({ length: newLength }).map((e, i) =>
+                      i % 2 === 0
+                        ? accNoEmptyElements[i / 2]
+                        : mockedBurnAll(`${concatDetailsIndex}-${i}-burn-all`)
+                    );
+                    return accWithMockedBurnAll.reduce((a, b) => a.concat(b), []);
+                  } else {
+                    return accNoEmptyElements.reduce((a, b) => a.concat(b), []);
+                  }
+                }
+              }, []);
+            } else {
+              return concatDetails;
+            }
+          } else {
+            return concatDetails;
+          }
+        })
+        .reduce((a, b) => a.concat(b), [])
+        .reduce((acc, cur, index, array) => {
+          if (index === 0) {
+            const nextSentTxIndex = array.findIndex(
+              el =>
+                (el.balance > 0 && el.detail.transactionType === "BURN") ||
+                (el.balance <= 0 &&
+                  el.detail.transactionType !== "BURN_BATON" &&
+                  el.detail.transactionType !== "BURN_ALL")
+            );
+            if (nextSentTxIndex !== -1) {
+              const lastUtxos = transactions.lastUnconfirmedSentTx
+                ? transactions.lastUnconfirmedSentTx.vin
+                : tokenUtxos;
+
+              const txIdInVin = array
+                .slice(0, nextSentTxIndex + 1)
+                .filter(
+                  el =>
+                    el.detail.transactionType !== "BURN_ALL" &&
+                    el.detail.transactionType !== "BURN_BATON" &&
+                    lastUtxos.filter(
+                      item =>
+                        item.txid === el.txid &&
+                        item.vout <= el.detail.outputs.length &&
+                        item.vout > 0
+                    ).length > 0
+                );
+              if (
+                txIdInVin.length ===
+                array
+                  .slice(0, nextSentTxIndex + 1)
+                  .filter(
+                    el =>
+                      el.detail.transactionType !== "BURN_ALL" &&
+                      el.detail.transactionType !== "BURN_BATON"
+                  ).length
+              ) {
+                return { result: array, lastIndex: nextSentTxIndex };
+              } else {
+                const insert = (arr, index, newItem) => [
+                  ...arr.slice(0, index),
+                  newItem,
+                  ...arr.slice(index)
+                ];
+
+                const mockedBurnAll = txid => ({
+                  txid,
+                  detail: { transactionType: "BURN_ALL" },
+                  vin: null,
+                  vout: null,
+                  balance: null,
+                  confirmations: null,
+                  date: null,
+                  time: null
+                });
+                const burnAllIndexes = array
+                  .slice(0, nextSentTxIndex + 1)
+                  .reduce((acc, cur, index) => {
+                    if (
+                      !txIdInVin.includes(cur) &&
+                      cur.detail.transactionType !== "BURN_ALL" &&
+                      cur.detail.transactionType !== "BURN_BATON"
+                    ) {
+                      acc.push(index);
+                    }
+                    return acc;
+                  }, []);
+
+                const slicedArrayWithBurnAllItems = burnAllIndexes.reduce((acc, cur, index) => {
+                  return insert(acc, cur + index, mockedBurnAll(`${cur + index}-burn-all`));
+                }, array);
+                return { result: slicedArrayWithBurnAllItems, lastIndex: nextSentTxIndex };
+              }
+            } else {
+              const lastUtxos = transactions.lastUnconfirmedSentTx
+                ? transactions.lastUnconfirmedSentTx.vin
+                : tokenUtxos;
+
+              const txIdInVin = array
+                .slice(0, array.length)
+                .filter(
+                  el =>
+                    el.detail.transactionType !== "BURN_ALL" &&
+                    el.detail.transactionType !== "BURN_BATON" &&
+                    lastUtxos.filter(
+                      item =>
+                        item.txid === el.txid &&
+                        item.vout <= el.detail.outputs.length &&
+                        item.vout > 0
+                    ).length > 0
+                );
+
+              if (
+                txIdInVin.length ===
+                array
+                  .slice(0, array.length)
+                  .filter(
+                    el =>
+                      el.detail.transactionType !== "BURN_ALL" &&
+                      el.detail.transactionType !== "BURN_BATON"
+                  ).length
+              ) {
+                return array.length > 1 ? { result: array, lastIndex: array.length - 1 } : array;
+              } else {
+                const mockedBurnAll = txid => ({
+                  txid,
+                  detail: { transactionType: "BURN_ALL" },
+                  vin: null,
+                  vout: null,
+                  balance: null,
+                  confirmations: null,
+                  date: null,
+                  time: null
+                });
+
+                const burnAllIndexes = array.slice(0, array.length).reduce((acc, cur, index) => {
+                  if (
+                    !txIdInVin.includes(cur) &&
+                    cur.detail.transactionType !== "BURN_ALL" &&
+                    cur.detail.transactionType !== "BURN_BATON"
+                  ) {
+                    acc.push(index);
+                  }
+                  return acc;
+                }, []);
+
+                const insert = (arr, index, newItem) => [
+                  ...arr.slice(0, index),
+                  newItem,
+                  ...arr.slice(index)
+                ];
+
+                const slicedArrayWithBurnAllItems = burnAllIndexes.reduce((acc, cur, index) => {
+                  return insert(acc, cur + index, mockedBurnAll(`${cur + index}-burn-all`));
+                }, array);
+                return { result: slicedArrayWithBurnAllItems, lastIndex: array.length - 1 };
+              }
+            }
+          } else {
+            if (index === acc.lastIndex && acc.lastIndex !== array.length - 1) {
+              const nextSentTx = array
+                .slice(index + 1)
+                .find(
+                  el =>
+                    (el.balance > 0 && el.detail.transactionType === "BURN") ||
+                    (el.balance <= 0 &&
+                      el.detail.transactionType !== "BURN_BATON" &&
+                      el.detail.transactionType !== "BURN_ALL")
+                );
+
+              const nextSentTxIndex = array
+                .slice(index + 1)
+                .findIndex(
+                  el =>
+                    (el.balance > 0 && el.detail.transactionType === "BURN") ||
+                    (el.balance <= 0 &&
+                      el.detail.transactionType !== "BURN_BATON" &&
+                      el.detail.transactionType !== "BURN_ALL")
+                );
+
+              if (nextSentTx && nextSentTx.time === array[acc.lastIndex].time) {
+                return { result: acc.result, lastIndex: nextSentTxIndex + index + 1 };
+              }
+
+              if (nextSentTxIndex !== -1 && nextSentTx.time !== array[acc.lastIndex].time) {
+                const txIdInVin = array
+                  .slice(index + 1, nextSentTxIndex + 1)
+                  .filter(
+                    el =>
+                      el.detail.transactionType !== "BURN_ALL" &&
+                      el.detail.transactionType !== "BURN_BATON" &&
+                      array[acc.lastIndex].vin.filter(
+                        item =>
+                          item.txid === el.txid &&
+                          item.vout <= el.detail.outputs.length &&
+                          item.vout > 0
+                      ).length > 0
+                  );
+
+                if (
+                  txIdInVin.length ===
+                  array
+                    .slice(index + 1, nextSentTxIndex + 1)
+                    .filter(
+                      el =>
+                        el.detail.transactionType !== "BURN_ALL" &&
+                        el.detail.transactionType !== "BURN_BATON"
+                    ).length
+                ) {
+                  return { result: acc.result, lastIndex: nextSentTxIndex };
+                } else {
+                  const insert = (arr, index, newItem) => [
+                    ...arr.slice(0, index),
+                    newItem,
+                    ...arr.slice(index)
+                  ];
+
+                  const mockedBurnAll = txid => ({
+                    txid,
+                    detail: { transactionType: "BURN_ALL" },
+                    vin: null,
+                    vout: null,
+                    balance: null,
+                    confirmations: null,
+                    date: null,
+                    time: null
+                  });
+                  const burnAllIndexes = array
+                    .slice(index + 1, nextSentTxIndex + 1)
+                    .reduce((acc, cur, itemIndex) => {
+                      if (
+                        !txIdInVin.includes(cur) &&
+                        cur.detail.transactionType !== "BURN_ALL" &&
+                        cur.detail.transactionType !== "BURN_BATON"
+                      ) {
+                        acc.push(itemIndex + index + 1);
+                      }
+                      return acc;
+                    }, []);
+
+                  const slicedArrayWithBurnAllItems = burnAllIndexes.reduce(
+                    (accItem, curItem, itemIndex) => {
+                      return insert(
+                        accItem,
+                        curItem + itemIndex,
+                        mockedBurnAll(`${curItem + itemIndex}-burn-all`)
+                      );
+                    },
+                    acc.result
+                  );
+                  return { result: slicedArrayWithBurnAllItems, lastIndex: nextSentTxIndex };
+                }
+              } else {
+                const txIdInVin = array
+                  .slice(index + 1)
+                  .filter(
+                    el =>
+                      el.detail.transactionType !== "BURN_ALL" &&
+                      el.detail.transactionType !== "BURN_BATON" &&
+                      array[acc.lastIndex].vin.filter(
+                        item =>
+                          item.txid === el.txid &&
+                          item.vout <= el.detail.outputs.length &&
+                          item.vout > 0
+                      ).length > 0
+                  );
+
+                if (
+                  txIdInVin.length ===
+                  array
+                    .slice(index + 1)
+                    .filter(
+                      el =>
+                        el.detail.transactionType !== "BURN_ALL" &&
+                        el.detail.transactionType !== "BURN_BATON"
+                    ).length
+                ) {
+                  return { result: acc.result, lastIndex: array.length - 1 };
+                } else {
+                  const insert = (arr, index, newItem) => [
+                    ...arr.slice(0, index),
+                    newItem,
+                    ...arr.slice(index)
+                  ];
+
+                  const mockedBurnAll = txid => ({
+                    txid,
+                    detail: { transactionType: "BURN_ALL" },
+                    vin: null,
+                    vout: null,
+                    balance: null,
+                    confirmations: null,
+                    date: null,
+                    time: null
+                  });
+
+                  const burnAllIndexes = array.slice(index + 1).reduce((acc, cur, itemIndex) => {
+                    if (
+                      !txIdInVin.includes(cur) &&
+                      cur.detail.transactionType !== "BURN_ALL" &&
+                      cur.detail.transactionType !== "BURN_BATON"
+                    ) {
+                      acc.push(itemIndex + index + 1);
+                    }
+                    return acc;
+                  }, []);
+
+                  const slicedArrayWithBurnAllItems = burnAllIndexes.reduce(
+                    (accItem, curItem, itemIndex) => {
+                      return insert(
+                        accItem,
+                        curItem + itemIndex,
+                        mockedBurnAll(`${curItem + itemIndex}-burn-all`)
+                      );
+                    },
+                    acc.result
+                  );
+                  return { result: slicedArrayWithBurnAllItems, lastIndex: array.length - 1 };
+                }
+              }
+            } else {
+              if (index === array.length - 1) {
+                return acc.result;
+              } else {
+                return acc;
+              }
+            }
+          }
+        }, [])
+        .filter(
+          (tx, index, array) =>
+            !(
+              tx.detail.transactionType === "BURN_ALL" &&
+              array.length > 1 &&
+              array[index + 1].detail.transactionType === "SEND" &&
+              array[index + 1].detail.outputs.length &&
+              array[index + 1].detail.outputs.findIndex(output =>
+                slpAddresses.includes(output.address)
+              ) === -1
+            )
+        );
+
+      const burnTxs = tokenTransactionHistory.confirmed.filter(
+        txDetail => txDetail.detail.transactionType === "BURN"
+      );
+
+      if (burnTxs.length > 0) {
+        const revertChunk = chunkedArray =>
+          chunkedArray.reduce((unchunkedArray, chunk) => [...unchunkedArray, ...chunk], []);
+        const burnTxIds = burnTxs.map(txDetail => txDetail.txid);
+        const txIdChunks = chunk(burnTxIds, 20);
+        const amounts = revertChunk(
+          await Promise.all(txIdChunks.map(txIdChunk => SLP.Utils.burnTotal(txIdChunk)))
+        );
+        tokenTransactionHistory.confirmed = tokenTransactionHistory.confirmed.map(txDetail =>
+          txDetail.detail.transactionType === "BURN"
+            ? {
+                ...txDetail,
+                detail: {
+                  ...txDetail.detail,
+                  burnAmount: (amounts.find(amount => amount.transactionId === txDetail.txid) || {})
+                    .burnTotal
+                }
+              }
+            : txDetail
+        );
+      }
     }
 
     const { unconfirmed, confirmed } = tokenTransactionHistory;

--- a/src/utils/getTransactionHistory.js
+++ b/src/utils/getTransactionHistory.js
@@ -161,9 +161,11 @@ const getTransactionHistory = async (SLP, cashAddresses, transactions, tokens) =
                 input => !cashAddresses.includes(SLP.Address.toCashAddress(input.legacyAddress))
               ) === -1))
         ) {
-          const previousBalance = Math.max(
-            ...vin.map(input => +(vin[0].valueSat ? input.valueSat : input.value))
-          );
+          const previousBalance = vin
+            .map(input => +(vin[0].valueSat ? input.valueSat : input.value))
+            .filter(el => el > 546)
+            .reduce((a, b) => +a + +b, 0);
+
           return {
             balance: (
               (+vout[0].value * Math.pow(10, 8) - previousBalance) *

--- a/src/utils/getTransactionHistory.js
+++ b/src/utils/getTransactionHistory.js
@@ -56,7 +56,7 @@ const decodeBchDividensMetaData = metaData => {
 
 const getTransactionHistory = async (SLP, cashAddresses, transactions, tokens) => {
   try {
-    const calculateTransactionBalance = vout => {
+    const calculateTransactionBalance = (vout, vin) => {
       const isDividends = isBchDividens(vout);
       if (isDividends) {
         if (
@@ -66,11 +66,14 @@ const getTransactionHistory = async (SLP, cashAddresses, transactions, tokens) =
           )
         ) {
           return {
-            balance:
+            balance: (
               vout
                 .slice(1, vout.length - 1)
-                .map(element => +element.value)
-                .reduce((a, b) => a + b, 0) * -1,
+                .map(element => +element.value * Math.pow(10, 8))
+                .reduce((a, b) => a + b, 0) *
+              Math.pow(10, -8) *
+              -1
+            ).toFixed(8),
             type: "MintDividend Sent",
             outputs: vout.slice(1, vout.length - 1).map(element => ({
               address: SLP.Address.toCashAddress(element.scriptPubKey.addresses[0]),
@@ -90,13 +93,17 @@ const getTransactionHistory = async (SLP, cashAddresses, transactions, tokens) =
             ) !== -1
         ) {
           return {
-            balance: vout
-              .slice(1, vout.length - 1)
-              .filter(element =>
-                cashAddresses.includes(SLP.Address.toCashAddress(element.scriptPubKey.addresses[0]))
-              )
-              .map(el => +el.value)
-              .reduce((a, b) => a + b, 0),
+            balance: (
+              vout
+                .slice(1, vout.length - 1)
+                .filter(element =>
+                  cashAddresses.includes(
+                    SLP.Address.toCashAddress(element.scriptPubKey.addresses[0])
+                  )
+                )
+                .map(el => +el.value * Math.pow(10, 8))
+                .reduce((a, b) => a + b, 0) * Math.pow(10, -8)
+            ).toFixed(8),
             type: "MintDividend Received",
             outputs: vout
               .slice(1, vout.length - 1)
@@ -120,11 +127,14 @@ const getTransactionHistory = async (SLP, cashAddresses, transactions, tokens) =
             ) === -1
         ) {
           return {
-            balance:
+            balance: (
               vout
                 .slice(1, vout.length)
-                .map(el => +el.value)
-                .reduce((a, b) => a + b, 0) * -1,
+                .map(el => +el.value * Math.pow(10, 8))
+                .reduce((a, b) => a + b, 0) *
+              Math.pow(10, -8) *
+              -1
+            ).toFixed(8),
             type: "MintDividend Sent",
             outputs: vout.slice(1, vout.length).map(el => ({
               address: SLP.Address.toCashAddress(el.scriptPubKey.addresses[0]),
@@ -139,6 +149,29 @@ const getTransactionHistory = async (SLP, cashAddresses, transactions, tokens) =
           type: "Unknown"
         };
       } else if (!hasOpReturn(vout)) {
+        if (
+          vout.length === 1 &&
+          cashAddresses.includes(SLP.Address.toCashAddress(vout[0].scriptPubKey.addresses[0])) &&
+          ((vin[0].addr &&
+            vin.findIndex(
+              input => !cashAddresses.includes(SLP.Address.toCashAddress(input.addr))
+            ) === -1) ||
+            (vin[0].legacyAddress &&
+              vin.findIndex(
+                input => !cashAddresses.includes(SLP.Address.toCashAddress(input.legacyAddress))
+              ) === -1))
+        ) {
+          const previousBalance = Math.max(
+            ...vin.map(input => +(vin[0].valueSat ? input.valueSat : input.value))
+          );
+          return {
+            balance: (
+              (+vout[0].value * Math.pow(10, 8) - previousBalance) *
+              Math.pow(10, -8)
+            ).toFixed(8),
+            type: "Change Received"
+          };
+        }
         if (
           vout.length === 1 &&
           cashAddresses.includes(SLP.Address.toCashAddress(vout[0].scriptPubKey.addresses[0]))
@@ -160,11 +193,14 @@ const getTransactionHistory = async (SLP, cashAddresses, transactions, tokens) =
           )
         ) {
           return {
-            balance:
+            balance: (
               vout
                 .slice(0, vout.length - 1)
-                .map(element => +element.value)
-                .reduce((a, b) => a + b, 0) * -1,
+                .map(element => +element.value * Math.pow(10, 8))
+                .reduce((a, b) => a + b, 0) *
+              Math.pow(10, -8) *
+              -1
+            ).toFixed(8),
             type: "Sent"
           };
         }
@@ -178,13 +214,17 @@ const getTransactionHistory = async (SLP, cashAddresses, transactions, tokens) =
             ) !== -1
         ) {
           return {
-            balance: vout
-              .slice(0, vout.length - 1)
-              .filter(element =>
-                cashAddresses.includes(SLP.Address.toCashAddress(element.scriptPubKey.addresses[0]))
-              )
-              .map(el => +el.value)
-              .reduce((a, b) => a + b, 0),
+            balance: (
+              vout
+                .slice(0, vout.length - 1)
+                .filter(element =>
+                  cashAddresses.includes(
+                    SLP.Address.toCashAddress(element.scriptPubKey.addresses[0])
+                  )
+                )
+                .map(el => +el.value * Math.pow(10, 8))
+                .reduce((a, b) => a + b, 0) * Math.pow(10, -8)
+            ).toFixed(8),
             type: "Received"
           };
         }
@@ -196,7 +236,11 @@ const getTransactionHistory = async (SLP, cashAddresses, transactions, tokens) =
           ) === -1
         ) {
           return {
-            balance: vout.map(element => +element.value).reduce((a, b) => a + b, 0) * -1,
+            balance: (
+              vout.map(element => +element.value * Math.pow(10, 8)).reduce((a, b) => a + b, 0) *
+              Math.pow(10, -8) *
+              -1
+            ).toFixed(8),
             type: "Sent"
           };
         }
@@ -232,7 +276,7 @@ const getTransactionHistory = async (SLP, cashAddresses, transactions, tokens) =
         txid: el.txid,
         date: new Date(),
         confirmations: el.confirmations,
-        transactionBalance: calculateTransactionBalance(el.vout)
+        transactionBalance: calculateTransactionBalance(el.vout, el.vin)
       }));
 
     const unconfirmedBchTxids = transactionHistory.unconfirmed.map(tx => tx.txid);
@@ -284,7 +328,7 @@ const getTransactionHistory = async (SLP, cashAddresses, transactions, tokens) =
           txid: el.txid,
           date: new Date(el.time * 1000),
           confirmations: el.confirmations,
-          transactionBalance: calculateTransactionBalance(el.vout)
+          transactionBalance: calculateTransactionBalance(el.vout, el.vin)
         }))
         .slice(0, 30 - transactionHistory.unconfirmed.length);
     }


### PR DESCRIPTION
- Burn tokens on token history

- Burn baton on token history

- "Burn All" indicator on token history

- "Change Received" added to BCH history

- History ordering for confirmed transactions on the same block or unconfirmed

Pending issues:
- Burned amount may not appear because of incorrect data, but amount left after burn always shows. It is possible to get this value in another way, but would take longer.

- Details on "Burn All" transactions and on "Change Received" are not shown. It's possible to get it on a second requisition.

![burn1](https://user-images.githubusercontent.com/4977560/76150939-2d4f0f80-608e-11ea-9203-a80ae325b836.png)

![burn2](https://user-images.githubusercontent.com/4977560/76150938-2cb67900-608e-11ea-95e0-56fe41579986.png)

![burn4](https://user-images.githubusercontent.com/4977560/76151259-c29fd300-6091-11ea-8cd5-d03dacf5ce47.png)


![burn3](https://user-images.githubusercontent.com/4977560/76150937-2b854c00-608e-11ea-9dbe-9542315b4e3a.png)
