### PR TITLE
Fix/create token with icon adjustments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3649,6 +3649,11 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "browser-image-compression": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-1.0.8.tgz",
+      "integrity": "sha512-Bc6AY16gweH9BzVFeaD4n6QmVvzDFyT4vxoNuVGNDCaHEmuehsobuYYY2yIVzHW9SHefRjShXOzs8Fj+3DUIew=="
+    },
     "browser-process-hrtime": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "badger-components-react": "^0.6.0",
     "big.js": "^5.2.2",
     "bignumber.js": "^9.0.0",
+    "browser-image-compression": "^1.0.8",
     "camelcase": "^5.2.0",
     "case-sensitive-paths-webpack-plugin": "2.2.0",
     "core-util-is": "^1.0.2",

--- a/src/components/Portfolio/Portfolio.js
+++ b/src/components/Portfolio/Portfolio.js
@@ -30,6 +30,7 @@ import getTokenTransactionHistory from "../../utils/getTokenTransactionHistory";
 import bchFlagLogo from "../../assets/4-bitcoin-cash-logo-flag.png";
 
 export const SLP_TOKEN_ICONS_URL = "https://tokens.bch.sx/64";
+export const BITCOIN_DOT_COM_ICONS_URL = "https://icons.btctest.net/64";
 
 export const StyledCollapse = styled(Collapse)`
   background: #fbfcfd !important;
@@ -73,6 +74,28 @@ export default () => {
   const [history, setHistory] = useState(null);
   const [outerAction, setOuterAction] = useState(false);
   const [showArchivedTokens, setShowArchivedTokens] = useState(false);
+
+  const getImgs = doc => {
+    return Array.from(doc.images)
+      .filter(
+        img => img.currentSrc.includes("tokens.bch.sx") || img.currentSrc.includes("https://icons.")
+      )
+      .map(
+        img =>
+          img.currentSrc
+            .split("/")
+            .slice()
+            .reverse()[0]
+            .split(".")[0]
+      );
+  };
+
+  React.useEffect(() => {
+    const tokenIconIds = getImgs(document);
+    if (tokenIconIds.length) {
+      tokenIconIds.map(id => window.localStorage.removeItem(id));
+    }
+  }, [tokens]);
 
   const isModalOpen = (action, selectedToken) => action === "sendBCH" || selectedToken !== null;
 
@@ -485,14 +508,24 @@ export default () => {
                             <Img
                               heigh={16}
                               width={16}
-                              src={`${SLP_TOKEN_ICONS_URL}/${token.tokenId}.png`}
+                              src={[
+                                `${BITCOIN_DOT_COM_ICONS_URL}/${token.tokenId}.png`,
+                                `${SLP_TOKEN_ICONS_URL}/${token.tokenId}.png`
+                              ]}
                               unloader={
                                 <img
                                   alt=""
                                   heigh={16}
                                   width={16}
-                                  style={{ borderRadius: "50%" }}
-                                  src={makeBlockie(token.tokenId)}
+                                  style={{
+                                    borderRadius: window.localStorage.getItem(token.tokenId)
+                                      ? null
+                                      : "50%"
+                                  }}
+                                  src={
+                                    window.localStorage.getItem(token.tokenId) ||
+                                    makeBlockie(token.tokenId)
+                                  }
                                 />
                               }
                             />
@@ -506,15 +539,25 @@ export default () => {
                   <Meta
                     avatar={
                       <Img
-                        src={`${SLP_TOKEN_ICONS_URL}/${token.tokenId}.png`}
+                        src={[
+                          `${BITCOIN_DOT_COM_ICONS_URL}/${token.tokenId}.png`,
+                          `${SLP_TOKEN_ICONS_URL}/${token.tokenId}.png`
+                        ]}
                         unloader={
                           <img
                             alt={`identicon of tokenId ${token.tokenId} `}
                             heigh="60"
                             width="60"
-                            style={{ borderRadius: "50%" }}
+                            style={{
+                              borderRadius: window.localStorage.getItem(token.tokenId)
+                                ? null
+                                : "50%"
+                            }}
                             key={`identicon-${token.tokenId}`}
-                            src={makeBlockie(token.tokenId)}
+                            src={
+                              window.localStorage.getItem(token.tokenId) ||
+                              makeBlockie(token.tokenId)
+                            }
                           />
                         }
                       />


### PR DESCRIPTION
### Add token icon adjustments:

**Before upload:**
- Any type of image file is accepted
- Any file size is accepted
- Image file is resized to 128px by 128px and transformed to PNG
- Resized file size is lesser than 50KB 

**After upload:**
- token icons are fetched from:
https://icons.btctest.net/64, if fails fallback to:
https://tokens.bch.sx/64

- If no image is returned from the above Urls, then icon image fallback to local storage image  if fails fallback  to default random Identicon "ethereum-blockies-base64"


Screenshots:

- Upload option:
![icon0](https://user-images.githubusercontent.com/4977560/76913177-fef2e080-6894-11ea-8555-64636475bc7f.png)

- Upload button:
![icon2](https://user-images.githubusercontent.com/4977560/76913173-fd291d00-6894-11ea-834f-b892ffbbbdc2.png)

- Image loaded:
![icon3](https://user-images.githubusercontent.com/4977560/76913168-fb5f5980-6894-11ea-89bb-97393bb11d30.png)

-On submit If no icon was added:
![icon4](https://user-images.githubusercontent.com/4977560/76913165-f9959600-6894-11ea-9614-41d346a8675c.png)

- If create icon fails, but create token is successful: 
![icon1](https://user-images.githubusercontent.com/4977560/76913181-00240d80-6895-11ea-8be1-09c6c4e90a31.png)
links to https://github.com/kosinusbch/slp-token-icons#adding-your-icon
