### PR TITLE
Added 'green' color to links in ant-card class

### DIFF
--- a/src/components/Common/StyledPage.js
+++ b/src/components/Common/StyledPage.js
@@ -10,6 +10,10 @@ const StyledPage = styled.div`
       box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.1);
     }
 
+    a {
+      color: rgb(93, 170, 126);
+    }
+
     * {
       color: rgb(62, 63, 66);
     }


### PR DESCRIPTION
Links inside ant-cards are the same color as the text. This pull request applies the green link styling.

Example - 

![non-colored](https://user-images.githubusercontent.com/972280/93670507-e3e27280-fa69-11ea-9d44-99795616d049.png)

- to - 

![colored-link](https://user-images.githubusercontent.com/972280/93670511-ee047100-fa69-11ea-9fcc-63945d678db2.png)
