### PR TITLE
Handle slpaddr error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - Bitcoin.com Mint
 
+## Oct 1, 2020
+
+- Correct error handling for user attempt to send SLP to BCH address
+- Correct error handling for user attempt to send SLP to invalid address
+- Introduce semantic versioning at 0.1.1
+
 ## Apr 29, 2020
 
 - Add icons with token creation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitico",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "homepage": "https://www.pitico.cash",
   "dependencies": {

--- a/src/components/Portfolio/Transfer/Transfer.js
+++ b/src/components/Portfolio/Transfer/Transfer.js
@@ -63,6 +63,8 @@ const Transfer = ({ token, onClose }) => {
         message = "Not enough BCH. Deposit some funds to use this feature.";
       } else if (/Token Receiver Address must be simpleledger format/.test(e.message)) {
         message = "Token Receiver Address must be simpleledger format.";
+      } else if (/Invalid BCH address. Double check your address is valid/.test(e.message)) {
+        message = "Invalid SLP address. Double check your address is valid.";
       } else if (!e.error) {
         message = `Transaction failed: no response from ${getRestUrl()}.`;
       } else if (/Could not communicate with full node or other external service/.test(e.error)) {

--- a/src/components/Portfolio/Transfer/Transfer.js
+++ b/src/components/Portfolio/Transfer/Transfer.js
@@ -61,6 +61,8 @@ const Transfer = ({ token, onClose }) => {
         message = "Invalid address";
       } else if (/Transaction input BCH amount is too low/.test(e.message)) {
         message = "Not enough BCH. Deposit some funds to use this feature.";
+      } else if (/Token Receiver Address must be simpleledger format/.test(e.message)) {
+        message = "Token Receiver Address must be simpleledger format.";
       } else if (!e.error) {
         message = `Transaction failed: no response from ${getRestUrl()}.`;
       } else if (/Could not communicate with full node or other external service/.test(e.error)) {


### PR DESCRIPTION
This PR corrects a longstanding UX bug. 

If a user attempts to send an SLP token to a BCH address, they receive an error message indicating that the REST API is down. Because the REST API is not infrequently down, this error usually leads to user frustration. Instead, all that is needed is to correct the format for the desitination address.

This PR introduces a more accurate error explanation and also handles the case of an invalid destination address.