### PR TITLE
Disable NFT send/mint transactions

### DIFF
--- a/src/components/Portfolio/Burn/Burn.js
+++ b/src/components/Portfolio/Burn/Burn.js
@@ -85,6 +85,7 @@ const Burn = ({ token, avatar, onClose }) => {
       if (hasBalance && formData.burnBaton === false) {
         link = await broadcastTransaction(wallet, {
           tokenId: token.tokenId,
+          version: token.version,
           amount: Number.parseFloat(formData.amount)
         });
 
@@ -100,6 +101,7 @@ const Burn = ({ token, avatar, onClose }) => {
       } else if (!hasBalance && hasBaton && formData.burnBaton === true) {
         link = await broadcastTransaction(wallet, {
           tokenId: token.tokenId,
+          version: token.version,
           additionalTokenQty: 0,
           batonReceiverAddress: null,
           burnBaton: true
@@ -117,6 +119,7 @@ const Burn = ({ token, avatar, onClose }) => {
       } else if (hasBalance && hasBaton && formData.burnBaton === true) {
         link = await broadcastTransaction(wallet, {
           tokenId: token.tokenId,
+          version: token.version,
           additionalTokenQty: 0,
           batonReceiverAddress: null,
           burnBaton: true
@@ -134,6 +137,7 @@ const Burn = ({ token, avatar, onClose }) => {
 
         link = await broadcastTransaction(wallet, {
           tokenId: token.tokenId,
+          version: token.version,
           amount: Number.parseFloat(formData.amount)
         });
 
@@ -157,6 +161,10 @@ const Burn = ({ token, avatar, onClose }) => {
         message = "Could not communicate with API. Please try again.";
       } else if (/Transaction input BCH amount is too low/.test(e.message)) {
         message = "Not enough BCH. Deposit some funds to use this feature.";
+      } else if (/NFT token types are not yet supported/.test(e.message)) {
+        message = e.message;
+      } else if (/is not supported/.test(e.message)) {
+        message = e.message;
       } else {
         message = e.message || e.error || JSON.stringify(e);
       }

--- a/src/components/Portfolio/Mint/Mint.js
+++ b/src/components/Portfolio/Mint/Mint.js
@@ -50,6 +50,7 @@ const Mint = ({ token, onClose }) => {
     try {
       const link = await mintToken(wallet, {
         tokenId: token.tokenId,
+        version: token.version,
         additionalTokenQty: quantity,
         batonReceiverAddress: baton
       });
@@ -75,6 +76,10 @@ const Mint = ({ token, onClose }) => {
         message = "Invalid BCH address";
       } else if (/Transaction input BCH amount is too low/.test(e.message)) {
         message = "Not enough BCH. Deposit some funds to use this feature.";
+      } else if (/NFT token types are not yet supported/.test(e.message)) {
+        message = e.message;
+      } else if (/is not supported/.test(e.message)) {
+        message = e.message;
       } else if (!e.error) {
         message = `Transaction failed: no response from ${getRestUrl()}.`;
       } else if (/Could not communicate with full node or other external service/.test(e.error)) {

--- a/src/components/Portfolio/Transfer/Transfer.js
+++ b/src/components/Portfolio/Transfer/Transfer.js
@@ -36,6 +36,7 @@ const Transfer = ({ token, onClose }) => {
     try {
       const link = await sendToken(wallet, {
         tokenId: token.tokenId,
+        version: token.version,
         amount: quantity,
         tokenReceiverAddress: address
       });
@@ -65,6 +66,10 @@ const Transfer = ({ token, onClose }) => {
         message = "Token Receiver Address must be simpleledger format.";
       } else if (/Invalid BCH address. Double check your address is valid/.test(e.message)) {
         message = "Invalid SLP address. Double check your address is valid.";
+      } else if (/NFT token types are not yet supported/.test(e.message)) {
+        message = e.message;
+      } else if (/is not supported/.test(e.message)) {
+        message = e.message;
       } else if (!e.error) {
         message = `Transaction failed: no response from ${getRestUrl()}.`;
       } else if (/Could not communicate with full node or other external service/.test(e.error)) {

--- a/src/utils/broadcastTransaction.js
+++ b/src/utils/broadcastTransaction.js
@@ -2,6 +2,19 @@ import withSLP from "./withSLP";
 
 const broadcastTransaction = async (SLPInstance, wallet, { ...args }) => {
   try {
+    // check supported token versions
+    if (args.version) {
+      switch (args.version) {
+        case 0x01:
+          break;
+        case 0x41:
+        case 0x81:
+          throw new Error("NFT token types are not yet supported.");
+        default:
+          throw new Error(`Token type ${args.version} is not supported.`);
+      }
+    }
+
     const NETWORK = process.env.REACT_APP_NETWORK;
 
     const TRANSACTION_TYPE =


### PR DESCRIPTION
Previously the wallet burns tokens because all slp transactions are built
using Token Type 1 fungible tokens.   NFT and NFT Group are disabled by
this commit.