### PR TITLE
Remove extra trailing forward slash

### DIFF
--- a/src/utils/withSLP.js
+++ b/src/utils/withSLP.js
@@ -2,7 +2,7 @@ import SLPSDK from "slp-sdk";
 
 export const getRestUrl = () =>
   process.env.REACT_APP_NETWORK === `mainnet`
-    ? window.localStorage.getItem("restAPI") || `https://rest.bch.actorforth.org/v2//`
+    ? window.localStorage.getItem("restAPI") || `https://rest.bch.actorforth.org/v2/`
     : window.localStorage.getItem("restAPI") || `https://trest.bitcoin.com/v2/`;
 
 export default callback => {


### PR DESCRIPTION
Having this extra slash at the end of the URL causes a 404 not found response.
Removing the slash fixes the issue.